### PR TITLE
More robust fix to allowing URLs to be passed into uncss

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,9 +64,13 @@ module.exports = function(grunt) {
         }
       },
       testUrl: {
-        files: {
-          'tests/outputUrl.css': 'http://getbootstrap.com/examples/jumbotron/'
-        },
+        files: [
+          {
+            nonull: true,
+            src: ['http://getbootstrap.com/examples/jumbotron/'],
+            dest: 'tests/outputUrl.css'
+          }
+        ]
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -121,11 +121,16 @@ uncss: {
 
 ```js
 // Remove unused CSS from URLs (php, node, etc.)
+// (Note that nonull must be true, or else Grunt removes remote paths that it can't find locally)
 uncss: {
   dist: {
-    files: {
-      'dist/css/tidy.css': ['http://localhost:8080']
-    }
+    files: [
+      {
+        nonull: true,
+        src: ['http://localhost:8080/path1', 'http://localhost:8080/path2'],
+        dest: 'dist/css/tidy.css'
+      }
+    ]
   }
 }
 ```

--- a/tasks/uncss.js
+++ b/tasks/uncss.js
@@ -20,24 +20,19 @@ module.exports = function ( grunt ) {
                 report: 'min'
             });
 
-        options.urls = options.urls || [];
-
         function processFile ( file, done ) {
 
             var src = file.src.filter(function ( filepath ) {
-                // Warn on and remove invalid source files (if nonull was set).
-                if ( !grunt.file.exists( filepath ) ) {
+                if (/^https?:\/\//.test(filepath)) {
+                    // This is a remote file: leave it in src array for uncss to handle.
+                    return true;
+                }
+                else if ( !grunt.file.exists( filepath ) ) {
+                    // Warn on and remove invalid local source files (if nonull was set).
                     grunt.log.warn( 'Source file ' + chalk.cyan( filepath ) + ' not found.' );
                     return false;
                 } else {
                     return true;
-                }
-            });
-
-            file.orig.src.forEach(function (source) {
-                if (/^https?/.test(source)) {
-                    src.push(source);
-                    options.urls.push(source);
                 }
             });
 


### PR DESCRIPTION
Unless `nonull: true` is set on file object, Grunt automatically
removes paths which it can’t find locally, preventing us from passing
remote paths to the plugin and to `uncss`.

The previous workaround was to use `file.orig.src` which still has
those paths, but that property fails to include multiple paths on a
single file object and seems to always be a string, not an array, so it
fails with `file.orig.src.forEach` not a function.

Additionally, `uncss` doesn't use `options.urls` so that has been
removed.
